### PR TITLE
bugfix in #handle_response when handling collections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.5.1] - 2016-08-16
+
+- bugfix in model helpers #handle_response when handling collections
+
 ## [0.5.0] - 2016-08-10
 
 - added few helpers:

--- a/lib/rancher/api/helpers/model.rb
+++ b/lib/rancher/api/helpers/model.rb
@@ -25,7 +25,15 @@ module Rancher
         end
 
         def handle_response(response)
-          raise RancherModelError, response.inspect if response.type.eql?('error')
+          case response
+          when Her::Collection
+            response
+          when Her::Model
+            raise RancherModelError, response.inspect if response.type.eql?('error')
+            response
+          else
+            raise RancherModelError, response.inspect
+          end
         end
 
         def wait_for_state(desired_state)

--- a/lib/rancher/api/version.rb
+++ b/lib/rancher/api/version.rb
@@ -1,5 +1,5 @@
 module Rancher
   module Api
-    VERSION = '0.5.0'.freeze
+    VERSION = '0.5.1'.freeze
   end
 end

--- a/spec/rancher/api/helpers/model_spec.rb
+++ b/spec/rancher/api/helpers/model_spec.rb
@@ -32,7 +32,7 @@ module Rancher
         describe '#run' do
           let(:test_url) { 'http://example.com/?action=test' }
           context 'action is available' do
-            let(:response) { double }
+            let(:response) { dummy }
             subject { dummy.run(:test) }
 
             it 'sends a POST request' do
@@ -56,6 +56,41 @@ module Rancher
             it 'raises a RancherActionNotAvailableError' do
               expect(dummy).to receive(:actions).and_return('test' => test_url).twice
               expect { dummy.run(:bogus)}.to raise_error(Model::RancherActionNotAvailableError)
+            end
+          end
+        end
+
+        describe '#handle_response' do
+          subject { dummy.handle_response(response) }
+
+          context 'response is a Her::Collection' do
+            let(:response) { Her::Collection.new }
+
+            it 'returns the collection' do
+              expect(subject).to eq(response)
+            end
+          end
+
+          context 'response is a Her::Model' do
+            let(:response) { dummy }
+
+            it 'returns the response' do
+              expect(dummy).to receive(:type).and_return('dummy')
+              expect(subject).to eq(response)
+            end
+
+            context 'response.type is "error"' do
+              it 'raises a RancherModelError' do
+                expect(dummy).to receive(:type).and_return('error')
+                expect { subject }.to raise_error(Model::RancherModelError)
+              end
+            end
+
+            context 'response is nil' do
+              it 'raises a RancherModelError' do
+                expect { dummy.handle_response(nil) }.to raise_error(Model::RancherModelError)
+
+              end
             end
           end
         end


### PR DESCRIPTION
Hi,

found a bug today in my code 😅 . It contains the #handle_response method in the model helper when running actions on collections.

I also added some info to changelog and bumped the version already.

👍 
