### PR TITLE
use environment api keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.7.0] - 2016-12-15
+
+### Changed
+
+- environment variable `RANCHER_URL` now must be set to environment url, i.e. `http://<rancher host>/v1/projects/1a9`
+
 ## [0.6.0] - 2016-12-14
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -76,6 +76,10 @@ end
 
 #### Using environment variables
 
+IMPORTANT NOTE: Use environment's API keys. This is done for compatibility with rancher-compose to utilize same keys
+
+    By default, the API keys under the API section are account API keys and you need to create an environment API key, which is in the Advanced Options.
+
 You can configure `rancher-api` gem using `rancher-compose`-compatible environment variables:
 
 - RANCHER_URL

--- a/lib/rancher/api/configuration.rb
+++ b/lib/rancher/api/configuration.rb
@@ -7,7 +7,7 @@ module Rancher
       attr_accessor :verbose
 
       def initialize
-        @url = "#{ENV['RANCHER_URL']}/v1/" if ENV['RANCHER_URL'].present?
+        @url = ENV['RANCHER_URL']
         @access_key = ENV['RANCHER_ACCESS_KEY']
         @secret_key = ENV['RANCHER_SECRET_KEY']
       end

--- a/lib/rancher/api/models/machine.rb
+++ b/lib/rancher/api/models/machine.rb
@@ -9,8 +9,6 @@ module Rancher
       DIGITAL_OCEAN = 'digitalocean'.freeze
       VMWARE_VSPHERE = 'vmwarevsphere'.freeze
 
-      collection_path 'projects/:project_id/machines'
-
       attributes :name, :state, :amazonec2Config, :azureConfig, :description,
                  :digitaloceanConfig, :driver, :exoscaleConfig, :externalId,
                  :labels, :openstackConfig, :packetConfig, :rackspaceConfig,

--- a/lib/rancher/api/version.rb
+++ b/lib/rancher/api/version.rb
@@ -1,5 +1,5 @@
 module Rancher
   module Api
-    VERSION = '0.6.0'.freeze
+    VERSION = '0.7.0'.freeze
   end
 end

--- a/spec/fixtures/environments/1e7.yml
+++ b/spec/fixtures/environments/1e7.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://XXX:YYY@192.168.99.100:8080/v1/environments/1e7
+    uri: http://XXX:YYY@192.168.99.100:8080/v1/projects/1a5/environments/1e7
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/environments/index.yml
+++ b/spec/fixtures/environments/index.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://XXX:YYY@192.168.99.100:8080/v1/environments
+    uri: http://XXX:YYY@192.168.99.100:8080/v1/projects/1a5/environments
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/environments/services.yml
+++ b/spec/fixtures/environments/services.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://XXX:YYY@192.168.99.100:8080/v1/environments/1e7/services
+    uri: http://XXX:YYY@192.168.99.100:8080/v1/projects/1a5/environments/1e7/services
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/projects/1a5.yml
+++ b/spec/fixtures/projects/1a5.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://XXX:YYY@192.168.99.100:8080/v1/projects/1a5
+    uri: http://XXX:YYY@192.168.99.100:8080/v1/projects/1a5/projects/1a5
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/projects/index.yml
+++ b/spec/fixtures/projects/index.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://XXX:YYY@192.168.99.100:8080/v1/projects
+    uri: http://XXX:YYY@192.168.99.100:8080/v1/projects/1a5/projects
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/projects/machines.yml
+++ b/spec/fixtures/projects/machines.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://XXX:YYY@192.168.99.100:8080/v1/projects/1a5/machines
+    uri: http://XXX:YYY@192.168.99.100:8080/v1/projects/1a5/projects/1a5/machines
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/projects/services.yml
+++ b/spec/fixtures/projects/services.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://XXX:YYY@192.168.99.100:8080/v1/projects/1a5/services
+    uri: http://XXX:YYY@192.168.99.100:8080/v1/projects/1a5/projects/1a5/services
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/services/1s3.yml
+++ b/spec/fixtures/services/1s3.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://XXX:YYY@192.168.99.100:8080/v1/services/1s3
+    uri: http://XXX:YYY@192.168.99.100:8080/v1/projects/1a5/services/1s3
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/services/1s55.yml
+++ b/spec/fixtures/services/1s55.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://XXX:YYY@192.168.99.100:8080/v1/services/1s55
+    uri: http://XXX:YYY@192.168.99.100:8080/v1/projects/1a5/services/1s55
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/services/1s55/instances.yml
+++ b/spec/fixtures/services/1s55/instances.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://XXX:YYY@192.168.99.100:8080/v1/services/1s55/instances
+    uri: http://XXX:YYY@192.168.99.100:8080/v1/projects/1a5/services/1s55/instances
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/services/1s9.yml
+++ b/spec/fixtures/services/1s9.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://XXX:YYY@192.168.99.100:8080/v1/services/1s9
+    uri: http://XXX:YYY@192.168.99.100:8080/v1/projects/1a5/services/1s9
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/rancher/api/models/machine_spec.rb
+++ b/spec/rancher/api/models/machine_spec.rb
@@ -12,7 +12,7 @@ module Rancher
 
       let(:index) do
         VCR.use_cassette('machines/index') do
-          project.machines.to_a
+          Machine.all.to_a
         end
       end
 
@@ -37,7 +37,7 @@ module Rancher
       describe '#find' do
         let(:machine) do
           VCR.use_cassette('machines/1ph1') do
-            Machine.find('1ph1', _project_id: project.id)
+            Machine.find('1ph1')
           end
         end
 

--- a/spec/rancher/api/models/project_spec.rb
+++ b/spec/rancher/api/models/project_spec.rb
@@ -43,7 +43,7 @@ describe Rancher::Api::Project do
     context '#environments' do
       let(:environments) do
         VCR.use_cassette('projects/environments') do
-          project.environments.to_a
+          Rancher::Api::Environment.all.to_a
         end
       end
 

--- a/spec/rancher/api/models/service_spec.rb
+++ b/spec/rancher/api/models/service_spec.rb
@@ -9,7 +9,7 @@ describe Rancher::Api::Service do
 
   let(:index) do
     VCR.use_cassette('services/index') do
-      project.services.to_a
+      Rancher::Api::Service.all.to_a
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,7 +11,7 @@ VCR.configure do |c|
 end
 
 Rancher::Api.configure do |config|
-  config.url = 'http://192.168.99.100:8080/v1/'
+  config.url = 'http://192.168.99.100:8080/v1/projects/1a5'
   config.access_key = 'XXX'
   config.secret_key = 'YYY'
 end


### PR DESCRIPTION
- let user make a decision about full url that `Rancher::Api` will use, this is done primarily to accommodate environment api keys, so that we can use the same settings with rancher-compose